### PR TITLE
Fix build scripts and config

### DIFF
--- a/scripts/generate-db-docs.ts
+++ b/scripts/generate-db-docs.ts
@@ -26,17 +26,6 @@ async function generateDbDocs() {
       ORDER BY 
         table_name;
     `) as QueryResult<TableRow>;
-      SELECT 
-        table_name,
-        obj_description(('public.' || table_name)::regclass, 'pg_class') as description
-      FROM 
-        information_schema.tables 
-      WHERE 
-        table_schema = 'public' 
-        AND table_type = 'BASE TABLE'
-      ORDER BY 
-        table_name;
-    `);
 
     // Get columns for each table
     const tablesWithColumns = await Promise.all(

--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -125,7 +125,7 @@ const reflectionPauses = [
   {
     id: uuidv4(),
     question: 'If you could ask the group one question that everyone must answer honestly, what would it be?',
-    description: 'Think about what you're curious to know',
+    description: "Think about what you're curious to know",
     duration_seconds: '120',
     is_active: true,
     theme: 'curiosity',

--- a/scripts/verify-game-flow.ts
+++ b/scripts/verify-game-flow.ts
@@ -21,6 +21,10 @@ function log(message: string) {
     process.stdout.write(`${message}\n`);
     // Also write to log file
     logFile.write(`${message}\n`);
+  } catch (error) {
+    console.error("Error writing to log:", error);
+  }
+}
 // Console colors for better readability
 const colors = {
   reset: '\x1b[0m',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
+  "extends": "./tsconfig.paths.json",
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
-    "scripts/**/*.ts",
+    "server/**/*.ts",
     "vite.config.ts"
   ],
   "exclude": [
     "node_modules",
     "dist",
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "scripts/**/*.ts",
   ],
   "compilerOptions": {
     /* Base Options */


### PR DESCRIPTION
## Summary
- fix db doc generator query duplication
- escape apostrophe in test seeding script
- add missing error handling in verify-game-flow logger
- update TypeScript config to extend path aliases and exclude scripts

## Testing
- `npx tsc --noEmit -p tsconfig.json`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684538400b70832c8c9d649c639e8e9e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during logging to prevent unhandled exceptions.
- **Chores**
	- Removed a redundant database query to streamline operations.
	- Updated configuration to exclude script files from compilation.
	- Adjusted string formatting for consistency in test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->